### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # shield
 [![Build Status](https://travis-ci.org/concordusapps/python-shield.png?branch=master)](https://travis-ci.org/concordusapps/python-shield)
 [![Coverage Status](https://coveralls.io/repos/concordusapps/python-shield/badge.png?branch=master)](https://coveralls.io/r/concordusapps/python-shield?branch=master)
-[![PyPi Version](https://pypip.in/v/shield/badge.png)](https://pypi.python.org/pypi/shield)
-[![PyPi Downloads](https://pypip.in/d/shield/badge.png)](https://pypi.python.org/pypi/shield)
+[![PyPi Version](https://img.shields.io/pypi/v/shield.svg)](https://pypi.python.org/pypi/shield)
+[![PyPi Downloads](https://img.shields.io/pypi/dm/shield.svg)](https://pypi.python.org/pypi/shield)
 > A permissions framework built around declarative rules that is ORM-agnostic.
 
 **Shield** faciltiates the creation of functional rules that define permissions on a *bearer* object optionally in relation to a *target* object. **Shield** is currently designed to work exclusively with sqlalchemy.


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20shield))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `shield`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.